### PR TITLE
Use Assertions

### DIFF
--- a/src/main/java/tlylt/haha/Parser.java
+++ b/src/main/java/tlylt/haha/Parser.java
@@ -30,6 +30,7 @@ public class Parser {
      * @return Command + details.
      */
     static String[] tokenize(String command) {
+        assert command.length() > 0 : "command is too short";
         return command.split(" ", 2);
     }
 
@@ -157,6 +158,7 @@ public class Parser {
         case "bye":
             return LegitCommand.BYE;
         default:
+            assert false : firstWord;
             throw new IllegalStateException("Unexpected value: " + firstWord);
         }
     }

--- a/src/main/java/tlylt/haha/TaskList.java
+++ b/src/main/java/tlylt/haha/TaskList.java
@@ -211,7 +211,8 @@ public class TaskList {
             this.updateFile();
             break;
         default:
-            throw new IllegalStateException("Unexpected value: " + command);
+            assert false : command;
+            throw new AssertionError(command);
         }
         return response;
     }


### PR DESCRIPTION
Without assertions, assumptions cannot be checked in switch statements.

Let's add in assert statements in default branch of switch statements.

If the code runs through the default branch, the assumption is wrong and
hence assertion error is invoked.